### PR TITLE
Bad syntax in the README example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -62,13 +62,13 @@ Install SSSD with custom configuration:
         'sssd' => {
           'key'     => 'value',
           'domains' => ['MY_DOMAIN', 'LDAP',],
-        }
+        },
         'domain/MY_DOMAIN' => {
           'key' => 'value',
-        }
+        },
         'pam' => {
           'key' => 'value',
-        }
+        },
       }
     }
 


### PR DESCRIPTION
A new user of your module would get syntax errors if he or she copy/pasted it directly into their manifest. I fixed it