### PR TITLE
Adding parameter include_default_config for being able to disable the…

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -83,6 +83,7 @@ Install SSSD with custom configuration:
                          'sssd-common' package.
 * `config`: A hash of configuration options stuctured like the sssd.conf file. Array values will be joined into comma-separated lists. 
 * `manage_idmap`: Boolean. Defaults to true. Set to false to disable management of the idmap package
+* `include_default_config`: Boolean. Defaults to true. Set to false to disable unmanaged default entries in 'sssd.conf'.
 * `manage_authconfig`: Boolean. Defaults to true. Set to false to disable management of the authconfig package
 
 For example:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,9 +2,17 @@
 #
 # This class is called from sssd
 #
-class sssd::config {
+class sssd::config (
 
-  $final_config = deep_merge($sssd::params::default_config, $sssd::config)
+  $include_default_config = $::sssd::include_default_config,
+
+) {
+
+  if $include_default_config {
+    $final_config = deep_merge($sssd::params::default_config, $sssd::config)
+  } else {
+    $final_config = $sssd::config
+  }
 
   file {'sssd_config_file':
     path    => $sssd::config_file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,9 @@
 # [*sample_parameter*]
 #   Explanation of what this parameter affects and what it defaults to.
 #
+# [*include_default_config*]
+#   Includ default configuration for 'sssd.conf'. Defaults to true.
+#
 class sssd (
 
   $sssd_package_name       = $sssd::params::sssd_package_name,
@@ -22,6 +25,7 @@ class sssd (
   $legacy_package_names    = $sssd::params::legacy_package_names,
   $manage_authconfig       = $sssd::params::manage_authconfig,
   $authconfig_package_name = $sssd::params::authconfig_package_name,
+  $include_default_config  = $sssd::params::include_default_config,
 
 ) inherits sssd::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,9 @@
 # It sets variables according to platform
 #
 class sssd::params {
+
+  $include_default_config = true
+
   case $::osfamily {
     'RedHat': {
       $sssd_package_name       = 'sssd'

--- a/metadata.json
+++ b/metadata.json
@@ -1,21 +1,27 @@
 {
   "name": "walkamongus-sssd",
   "version": "1.2.3",
-  "source": "https://github.com/walkamongus/sssd.git",
   "author": "Chadwick Banning",
-  "license": "Apache 2.0",
   "summary": "Install and configure the System Security Services Daemon",
-  "description": "Install and configure the System Security Services Daemon",
+  "license": "Apache 2.0",
+  "source": "https://github.com/walkamongus/sssd.git",
   "project_page": "https://github.com/walkamongus/sssd",
-  "tags": ["sssd"],
+  "issues_url": "https://github.com/walkamongus/sssd/issues",
+  "dependencies": [
+    {"name":"puppetlabs/stdlib","version_requirement":">= 3.4.0 < 5.0.0"}
+  ],
+  "data_provider": null,
+  "description": "Install and configure the System Security Services Daemon",
+  "tags": [
+    "sssd"
+  ],
   "operatingsystem_support": [
     {
-    "operatingsystem":"RedHat",
-    "operatingsystemrelease":[ "6.0" ]
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6.0"
+      ]
     }
-   ],
-  "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 3.4.0 < 5.0.0" }
   ],
   "requirements": [
     {


### PR DESCRIPTION
… sssd default configuration. This still defaults to 'true' in order to behave like the original module. Setting this parameter to fault will disable the default configuration and only implement settings that are specified.